### PR TITLE
optional dependency on bz-dsr-bridge

### DIFF
--- a/omnimatter_permutation/info.json
+++ b/omnimatter_permutation/info.json
@@ -18,6 +18,7 @@
     "?PyCoalTBaA",
     "?MoreSciencePacks",
     "?MomoTweak",
+    "?bz-dsr-bridge",
     "(?)pypostprocessing"
 ]
 }


### PR DESCRIPTION
To enforce mod load order and fix some issues when used with BZ mods

Relevant thread: https://mods.factorio.com/mod/bzvery/discussion/62b5ee7da4768275fef909c1