### PR TITLE
Mining_Drones_Remastered support

### DIFF
--- a/omnimatter_fluid/data-final-fixes.lua
+++ b/omnimatter_fluid/data-final-fixes.lua
@@ -1,11 +1,10 @@
---Ignore mining drones recipes to not break its script when replacing the fluid
+--Ignore recipes of Mining_Drones and most of its forks, including Mining_Drones_Remastered
+--To not break their behaviour when replacing the fluid
 --This has to be in final fixes AND before sluids generation
-if mods["Mining_Drones"] then
-    for _, rec in pairs(data.raw.recipe) do
-        if rec.category == "mining-depot" and string.find(rec.name,"mine%-") then
-            --log("Excluded recipe "..rec.name)
-            omni.fluid.excempt_recipe(rec.name)
-        end
+for _, rec in pairs(data.raw.recipe) do
+    if rec.category == "mining-depot" and string.find(rec.name,"mine%-") then
+        --log("Excluded recipe "..rec.name)
+        omni.fluid.excempt_recipe(rec.name)
     end
 end
 


### PR DESCRIPTION
OmniFluid will now support almost any fork of Mining_Drones, not changing their required fluid. [Requested in MD2R discussions](https://mods.factorio.com/mod/Mining_Drones_Remastered/discussion/650b0eafebe76e8acb500fa3).