### PR TITLE
Fix nil access errors in control.lua when technologies unlock non-compression recipes

### DIFF
--- a/omnilib/control.lua
+++ b/omnilib/control.lua
@@ -328,9 +328,10 @@ local function omnidate(technology)
                 end
                 -- Iterate techs, set their given recipe state
                 for tech_name, tech_recipes in pairs(recipe_techs) do
-                    if force_techs[tech_name].researched then
+                    local tech = force_techs[tech_name]
+                    if tech and tech.researched then
                         for recipe_name, recipe_meta in pairs(tech_recipes) do
-                            process_rec(recipe_name, recipe_meta, force_techs[tech_name].researched)
+                            process_rec(recipe_name, recipe_meta, tech.researched)
                         end
                     end
                 end


### PR DESCRIPTION
## Problem

When a technology that unlocks recipes without compression variants is researched (e.g., via `research_trigger` when mining an entity), omnilib's `omnidate` function crashes with "bool expected, got nil" errors. This affects compatibility with mods that add trigger-based technologies like Planetaris-Arig's cactus wood technology.

<img width="609" height="432" alt="image" src="https://github.com/user-attachments/assets/527ba063-3d52-4d61-93d4-95897037b4c5" />

## Root Cause

The `omnidate` function and its helper `process_rec` assumed that:
1. All recipes unlocked by technologies would have entries in `correlated_recipes`
2. All forces would have the `compression-recipes` technology
3. All recipe lookups in `cached_recs` and `force_techs` would return valid objects

When these assumptions failed, nil values propagated through the code and eventually caused Factorio to reject nil where it expected a boolean for `.enabled` properties.

## Changes

1. **Added nil guard in `process_rec`** (line 302): Early return if `rec_meta` is nil, preventing iteration over nil values.

2. **Added nil checks for `cached_recs` lookups** (lines 307-324): Before accessing `.enabled` on recipe objects, verify the recipe exists for the current force.

3. **Fixed unsafe access to `correlated_recipes`** (lines 317-318, 59): Split chained property access like `correlated_recipes[name].compressed` into safe two-step lookups.

4. **Added nil check for `force_techs` lookup** (lines 340-344): Before accessing `.researched` on a technology, verify it exists for the current force.

5. **Ensured `has_compression` is always boolean** (line 254): Added `or false` to prevent nil from propagating when `compression-recipes` technology doesn't exist.

## Testing

Tested with `Planetaris-Arig` mod; mining a cactus (which triggers the `planetaris-cactus-wood` technology via `research_trigger`) no longer crashes the game.

## Compatibility

These changes are backwards compatible and defensive in nature; they add nil checks without changing the logic for cases where values are present.
