### PR TITLE
Fix automation-science-pack research blocked by hidden electronics pr…

### DIFF
--- a/omnimatter_energy/prototypes/compat/krastorio2.lua
+++ b/omnimatter_energy/prototypes/compat/krastorio2.lua
@@ -16,7 +16,7 @@ if mods["Krastorio2"] then
         setTechIcons({{icon = "__Krastorio2Assets__/icons/cards/basic-tech-card.png",icon_size = 64}}):
         setTechPacks({{"energy-science-pack", 1}}):
         setTechPrereq("omnitech-anbaricity"):
-        setTechLocName(omni.lib.locale.of("kr-basic-tech-card", "recipe")):
+        setTechLocName(omni.lib.locale.of("kr-basic-tech-card", "recipe").name):
         extend()
 
     --Turn the energy SP into a "card", thanks to the K2 team for letting us use a changed version of their card icon
@@ -41,9 +41,11 @@ if mods["Krastorio2"] then
 
     --Remove electronics, K2 fixed up vanilla electronics
     TechGen:import("electronics"):setPrereq(nil):setUpgrade(false):setEnabled(true):nullUnlocks():sethidden():extend()
+    --Also remove electronics from all technologies that have it as a prerequisite since it's now hidden
+    omni.lib.remove_prerequisite("automation-science-pack", "electronics")
+    omni.lib.remove_prerequisite("fast-inserter", "electronics")
+    omni.lib.remove_prerequisite("logistic-science-pack", "electronics")
 
-    --Fix automation SP locales
-    data.raw.technology["automation-science-pack"].localised_name = {"technology-name.automation-tech-card"}
 
     --Move wind turbine to anbaricity
     RecGen:import("kr-wind-turbine"):


### PR DESCRIPTION
## Summary
Fix multiple technologies being unresearchable when Krastorio2 and omnimatter_energy are enabled together.
## Problem
When both mods are enabled, several technologies show as "unreachable" even after completing all visible prerequisites. This is because:
1. The `electronics` technology is hidden by omnimatter_energy
2. But multiple technologies still have `electronics` as a prerequisite:
   - `automation-science-pack`
   - `fast-inserter`
   - `logistic-science-pack`
Additionally, `kr-basic-tech-card` technology shows "Unknown key" localization error.
## Solution
- Remove `electronics` from `automation-science-pack` prerequisites since it's hidden
- Remove `electronics` from `fast-inserter` prerequisites
- Remove `electronics` from `logistic-science-pack` prerequisites
- Fix `kr-basic-tech-card` tech localization by using `.name` property from locale resolver
## Testing
Verified in-game that:
- `automation-science-pack` can be researched after completing `kr-laboratory`
- `fast-inserter` can be researched after completing its remaining prerequisites
- `kr-basic-tech-card` displays correct localized name