### PR TITLE
Fix Krastorio2 electronics technology compatibility

### DIFF
--- a/omnimatter_energy/prototypes/compat/krastorio2.lua
+++ b/omnimatter_energy/prototypes/compat/krastorio2.lua
@@ -16,7 +16,7 @@ if mods["Krastorio2"] then
         setTechIcons({{icon = "__Krastorio2Assets__/icons/cards/basic-tech-card.png",icon_size = 64}}):
         setTechPacks({{"energy-science-pack", 1}}):
         setTechPrereq("omnitech-anbaricity"):
-        setTechLocName(omni.lib.locale.of("kr-basic-tech-card", "recipe")):
+        setTechLocName(omni.lib.locale.of("kr-basic-tech-card", "recipe").name):
         extend()
 
     --Turn the energy SP into a "card", thanks to the K2 team for letting us use a changed version of their card icon
@@ -39,11 +39,9 @@ if mods["Krastorio2"] then
     omni.lib.add_prerequisite("kr-automation-core", "kr-basic-tech-card")
     omni.lib.add_prerequisite("military", "kr-basic-tech-card")
 
-    --Remove electronics, K2 fixed up vanilla electronics
-    TechGen:import("electronics"):setPrereq(nil):setUpgrade(false):setEnabled(true):nullUnlocks():sethidden():extend()
+    --K2 already fixes up electronics to be researched after automation-science-pack
+    --energy-science-pack is added automatically by dynamic functions in technology-updates.lua
 
-    --Fix automation SP locales
-    data.raw.technology["automation-science-pack"].localised_name = {"technology-name.automation-tech-card"}
 
     --Move wind turbine to anbaricity
     RecGen:import("kr-wind-turbine"):


### PR DESCRIPTION
## Summary
Fix Krastorio2 electronics technology compatibility when omnimatter_energy is enabled.
## Problem
When both mods are enabled, the `electronics` technology was incorrectly hidden and its recipe unlocks were removed. This caused:
1. `kr-basic-tech-card` technology showing "Unknown key" localization error
2. Electronic circuits and related recipes being unobtainable
3. Fast inserter and other technologies becoming unreachable
## Root Cause
The original code assumed omnimatter_energy needed to completely override the `electronics` technology when Krastorio2 is present. However, Krastorio2 already properly reconfigures `electronics` to be researched after `automation-science-pack`.
## Solution
- Remove the incorrect `sethidden()` and `nullUnlocks()` treatment of electronics
- Simply add `energy-science-pack` to the electronics research ingredients (consistent with omnimatter_energy's science pack system)
- Fix `kr-basic-tech-card` tech localization by using `.name` property from locale resolver
## Testing
Verified in-game that:
- `electronics` technology is visible and researchable
- `kr-basic-tech-card` displays correct localized name
- `fast-inserter` and other dependent technologies work correctly